### PR TITLE
Fix shell command in the instructions for testing

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -31,7 +31,7 @@ To test the overall setup, please execute the following commands to setup the Mi
 
 ````sh
 docker pull seppinho/cloudgene-docker
-sudo docker run --privileged -it -p 8082:8082 seppinho/cloudgene-docker --repository https://github.com/genepi/imputationserver.git
+sudo docker run --privileged -it -p 8082:8082 seppinho/cloudgene-docker start-cloudgene.sh --repository https://github.com/genepi/imputationserver.git
 ````
 
 ### Connect


### PR DESCRIPTION
Running the original results in the following error:

docker: Error response from daemon: oci runtime error: container_linux.go:247: starting container process caused "exec: \"--repository\": executable file not found in $PATH"

The fix gets rid of the error by telling Docker to use the script "start-cloudgene.sh" to execute the repository.