### PR TITLE
Add file checksums for imputation results

### DIFF
--- a/src/main/java/genepi/imputationserver/util/FileChecksum.java
+++ b/src/main/java/genepi/imputationserver/util/FileChecksum.java
@@ -1,0 +1,69 @@
+package genepi.imputationserver.util;
+
+import org.apache.commons.codec.binary.Hex;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Generate file checksums to be used for file integrity verification.
+ */
+public class FileChecksum {
+
+    /**
+     * Types of algorithms to be used for hashing.
+     */
+    public enum Algorithm {
+        /**
+         * MD5 hash
+         */
+        MD5("MD5"),
+        /**
+         * SHA-1 hash
+         */
+        SHA1("SHA-1"),
+        /**
+         * SHA-256 hash
+         */
+        SHA256("SHA-256");
+
+        private final String type;
+
+        Algorithm(String type) {
+            this.type = type;
+        }
+
+        public String getType() {
+            return type;
+        }
+    }
+
+    /**
+     * Returns a checksum based on the specified {@code Algorithm} type.
+     *
+     * @param file      the file for which a checksum will be created
+     * @param algorithm the type of {@code Algorithm} requested.
+     * @return A String of the file checksum
+     * @throws IOException              if {@code file} is not found.
+     * @throws NoSuchAlgorithmException if {@code algorithm} is not supported
+     */
+    public static String HashFile(File file, Algorithm algorithm) throws IOException, NoSuchAlgorithmException {
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            MessageDigest digest = MessageDigest.getInstance(algorithm.getType());
+
+            byte[] bytesBuffer = new byte[4096];
+            int bytesRead;
+
+            while ((bytesRead = inputStream.read(bytesBuffer)) != -1) {
+                digest.update(bytesBuffer, 0, bytesRead);
+            }
+
+            byte[] hashedBytes = digest.digest();
+
+            return Hex.encodeHexString(hashedBytes);
+        }
+    }
+}

--- a/src/test/java/genepi/imputationserver/util/FileChecksumTest.java
+++ b/src/test/java/genepi/imputationserver/util/FileChecksumTest.java
@@ -1,0 +1,45 @@
+package genepi.imputationserver.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+
+public class FileChecksumTest {
+    private static final String MD5CHECKSUM = "14fdae51731c8b9c15758b7b488ebc5e";
+    private static final String SHA1CHECKSUM = "78af2bee1b95c6f8348b583240b11cd748a946f3";
+    private static final String SHA256CHECKSUM = "2f342db135cdf887311c871c7eeb99f8c1587e6e248ae0ba953c12958fe1e396";
+    private static final File MOCKVCF = new File("test-data/data/chr20-phased/chr20.R50.merged.1.330k.recode.small.vcf.gz");
+
+    @Test
+    public void md5Checksum() {
+        try {
+            String checksum = FileChecksum.HashFile(MOCKVCF, FileChecksum.Algorithm.MD5);
+            Assert.assertEquals(MD5CHECKSUM, checksum);
+        } catch (IOException | NoSuchAlgorithmException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    @Test
+    public void sha1Checksum() {
+        try {
+            String checksum = FileChecksum.HashFile(MOCKVCF, FileChecksum.Algorithm.SHA1);
+            Assert.assertEquals(SHA1CHECKSUM, checksum);
+        } catch (IOException | NoSuchAlgorithmException ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    @Test
+    public void sha256Checksum() {
+        try {
+            String checksum = FileChecksum.HashFile(MOCKVCF, FileChecksum.Algorithm.SHA256);
+            Assert.assertEquals(SHA256CHECKSUM, checksum);
+        } catch (IOException | NoSuchAlgorithmException ex) {
+            ex.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Adds file checksum generation for imputation results. Currently configured to use MD5 for file checksums. However, SHA-1 and SHA-256 functionality is also implemented.