### PR TITLE
Update htsjdk to 3.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,7 +230,7 @@
 		<dependency>
 			<groupId>com.github.samtools</groupId>
 			<artifactId>htsjdk</artifactId>
-			<version>3.0.1</version>
+			<version>3.0.4</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
This pull request updates htsjdk to 3.0.4. To be sure to fix the known bug in VCF sort (see https://github.com/samtools/htsjdk/releases/tag/3.0.4)