### PR TITLE
v1.8.0-beta4

### DIFF
--- a/files/imputationserver-beagle.yaml
+++ b/files/imputationserver-beagle.yaml
@@ -1,7 +1,7 @@
 id: imputationserver-beagle
 name: Genotype Imputation supporting Beagle (Minimac4)
 description: This is the new Michigan Imputation Server Pipeline using <a href="https://github.com/statgen/Minimac4">Minimac4</a>. Documentation can be found <a href="http://imputationserver.readthedocs.io/en/latest/">here</a>.<br><br>If your input data is <b>GRCh37/hg19</b> please ensure chromosomes are encoded without prefix  (e.g. <b>20</b>).<br>If your input data is <b>GRCh38hg38</b> please ensure chromosomes are encoded with prefix 'chr' (e.g. <b>chr20</b>).
-version: 1.8.0-beta3
+version: 1.8.0-beta4
 website: https://imputationserver.readthedocs.io
 category:
 

--- a/files/imputationserver-hla.yaml
+++ b/files/imputationserver-hla.yaml
@@ -1,7 +1,7 @@
 id: imputationserver-hla
 name: Genotype Imputation HLA (Minimac4)
 description: This is the new Michigan Imputation Server Pipeline using <a href="https://github.com/statgen/Minimac4">Minimac4</a>. Documentation can be found <a href="http://imputationserver.readthedocs.io/en/latest/">here</a>.<br><br>If your input data is <b>GRCh37/hg19</b> please ensure chromosomes are encoded without prefix  (e.g. <b>20</b>).<br>If your input data is <b>GRCh38hg38</b> please ensure chromosomes are encoded with prefix 'chr' (e.g. <b>chr20</b>).
-version: 1.8.0-beta3
+version: 1.8.0-beta4
 website: https://imputationserver.readthedocs.io
 category:
 

--- a/files/imputationserver-pgs.yaml
+++ b/files/imputationserver-pgs.yaml
@@ -1,7 +1,7 @@
 id: imputationserver-pgs
 name: Genotype Imputation (PGS Calc Integration)
 description: This is the new Michigan Imputation Server Pipeline using <a href="https://github.com/statgen/Minimac4">Minimac4</a>. Documentation can be found <a href="http://imputationserver.readthedocs.io/en/latest/">here</a>.<br><br>If your input data is <b>GRCh37/hg19</b> please ensure chromosomes are encoded without prefix  (e.g. <b>20</b>).<br>If your input data is <b>GRCh38hg38</b> please ensure chromosomes are encoded with prefix 'chr' (e.g. <b>chr20</b>).
-version: 1.8.0-beta3
+version: 1.8.0-beta4
 website: https://imputationserver.readthedocs.io
 category:
 

--- a/files/minimac4.yaml
+++ b/files/minimac4.yaml
@@ -1,7 +1,7 @@
 id: imputationserver
 name: Genotype Imputation (Minimac4)
 description: This is the new Michigan Imputation Server Pipeline using <a href="https://github.com/statgen/Minimac4">Minimac4</a>. Documentation can be found <a href="http://imputationserver.readthedocs.io/en/latest/">here</a>.<br><br>If your input data is <b>GRCh37/hg19</b> please ensure chromosomes are encoded without prefix  (e.g. <b>20</b>).<br>If your input data is <b>GRCh38hg38</b> please ensure chromosomes are encoded with prefix 'chr' (e.g. <b>chr20</b>).
-version: 1.8.0-beta3
+version: 1.8.0-beta4
 website: https://imputationserver.readthedocs.io
 category:
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>genepi</groupId>
 	<artifactId>imputationserver</artifactId>
-	<version>1.8.0-beta3</version>
+	<version>1.8.0-beta4</version>
 	<packaging>jar</packaging>
 	<name>University of Michigan Imputation Server</name>
 	<url>http://maven.apache.org</url>

--- a/src/main/java/genepi/imputationserver/steps/imputation/ImputationPipeline.java
+++ b/src/main/java/genepi/imputationserver/steps/imputation/ImputationPipeline.java
@@ -24,9 +24,9 @@ import lukfor.progress.tasks.Task;
 
 public class ImputationPipeline {
 
-	public static final String PIPELINE_VERSION = "michigan-imputationserver-1.8.0-beta3";
+	public static final String PIPELINE_VERSION = "michigan-imputationserver-1.8.0-beta4";
 
-	public static final String IMPUTATION_VERSION = "minimac-v4.1.5";
+	public static final String IMPUTATION_VERSION = "minimac-v4.1.6";
 
 	public static final String BEAGLE_VERSION = "beagle.18May20.d20.jar";
 


### PR DESCRIPTION
## Purpose
Prepares a new version of imputatioserver (based on `feature/msav-support`) that uses updated minimac 4.1.6.

I will be testing this in parallel in the TIS environment this afternoon. Made available here due to the narrow release timeline.


Provenance: binary comes from installer script
https://github.com/statgen/Minimac4/releases/tag/v4.1.6